### PR TITLE
Glib API harmonization

### DIFF
--- a/examples/print_all_secrets.rs
+++ b/examples/print_all_secrets.rs
@@ -12,10 +12,7 @@ fn main() {
             println!("Collection is locked");
             secret_collection.unlock().ok().unwrap();
         }
-        let all_items = match secret_collection.get_items(){
-            Some(items) => items,
-            None => continue
-        };
+        let all_items = secret_collection.get_items();
 
         for secret_item in all_items {
             println!("Label for item: {}", secret_item.get_label());

--- a/libsecret-sys/src/lib.rs
+++ b/libsecret-sys/src/lib.rs
@@ -62,6 +62,7 @@ extern "C" {
     pub fn secret_collection_get_locked     (secret_collection: *mut SecretCollectionFFI) -> gboolean;
     pub fn secret_collection_get_modified   (secret_collection: *mut SecretCollectionFFI) -> guint64;
     pub fn secret_collection_refresh        (secret_collection: *mut SecretCollectionFFI);
+    pub fn secret_collection_get_type       () -> GType;
 
     //=========================================================================
     // SecretItem

--- a/src/secret_collection.rs
+++ b/src/secret_collection.rs
@@ -4,7 +4,7 @@ use glib::Error;
 use glib::ffi::{GObject};
 use glib::object::{Wrapper, Ref};
 use glib::types::{StaticType, Type};
-use glib::translate::{ToGlibPtr, FromGlib, FromGlibPtr, FromGlibPtrContainer};
+use glib::translate::*;
 use glib::glib_container::GlibContainer;
 use secret_service::SecretService;
 use secret_item::SecretItem;
@@ -118,7 +118,7 @@ impl SecretCollection {
 
 impl StaticType for SecretCollection {
     fn static_type() -> Type{
-        Type::BaseObject
+        unsafe { from_glib(ffi::secret_collection_get_type()) }
     }
 }
 

--- a/src/secret_collection.rs
+++ b/src/secret_collection.rs
@@ -45,46 +45,46 @@ impl SecretCollection {
     /// Get the created date and time of the collection.
     /// The return value is the number of seconds since the unix epoch, January 1st 1970.
     pub fn get_created(&self) -> u64 {
-        unsafe {ffi::secret_collection_get_created(self.raw())}
+        unsafe {ffi::secret_collection_get_created(self.to_glib_none().0)}
     }
 
     /// Get the modified date and time of the collection.
     /// The return value is the number of seconds since the unix epoch, January 1st 1970.
     pub fn get_modified(&self) -> u64 {
-        unsafe {ffi::secret_collection_get_modified(self.raw())}
+        unsafe {ffi::secret_collection_get_modified(self.to_glib_none().0)}
     }
 
     /// Get the Secret Service object that this collection was created with.
     pub fn get_service(&self) -> SecretService { //TODO find out if this can return null
         unsafe {
-            let ptr = ffi::secret_collection_get_service(self.raw());
+            let ptr = ffi::secret_collection_get_service(self.to_glib_none().0);
             SecretService::wrap(Ref::from_glib_none(ptr as *mut GObject))
         }
     }
 
     pub fn are_items_loaded(&self) -> bool {
-        let flags = unsafe {ffi::secret_collection_get_flags(self.raw())};
+        let flags = unsafe {ffi::secret_collection_get_flags(self.to_glib_none().0)};
         flags & SECRET_COLLECTION_LOAD_ITEMS != 0
     }
 
     /// Get the label of this collection.
     pub fn get_label(&self) -> String {
         unsafe{
-            let ptr = ffi::secret_collection_get_label(self.raw());
+            let ptr = ffi::secret_collection_get_label(self.to_glib_none().0);
             FromGlibPtr::from_glib_none(ptr)
         }
     }
 
     /// Get whether the collection is locked or not.
     pub fn get_locked(&self) -> bool {
-        let gbool = unsafe{ffi::secret_collection_get_locked(self.raw())};
+        let gbool = unsafe{ffi::secret_collection_get_locked(self.to_glib_none().0)};
         FromGlib::from_glib(gbool)
     }
 
     /// Returns None, if the items have not yet been loaded.
     pub fn get_items(&self) -> Option<Vec<SecretItem>> {
         unsafe {
-            let glist = ffi::secret_collection_get_items(self.raw());
+            let glist = ffi::secret_collection_get_items(self.to_glib_none().0);
             if glist.is_null(){
                 None
             } else {
@@ -94,17 +94,11 @@ impl SecretCollection {
 
     }
 
-
-    #[inline]
-    fn raw(&self) -> *mut ffi::SecretCollectionFFI {
-        self.0.to_glib_none() as *mut ffi::SecretCollectionFFI
-    }
-
     /// Ensure that the SecretCollection proxy has loaded all the items present in the Secret Service.
     pub fn load_items(&self) -> SecretResult<()>{
         unsafe {
             let mut err = ptr::null_mut();
-            ffi::secret_collection_load_items_sync(self.raw(), ptr::null_mut(), &mut err);
+            ffi::secret_collection_load_items_sync(self.to_glib_none().0, ptr::null_mut(), &mut err);
             if err.is_null() {
                 Ok(())
             } else {

--- a/src/secret_collection.rs
+++ b/src/secret_collection.rs
@@ -1,5 +1,4 @@
 use std::ptr;
-use libc::{c_int};
 use glib::Error;
 use glib::object::{Object, Upcast, Wrapper, Ref};
 use glib::types::{StaticType, Type};
@@ -33,7 +32,7 @@ impl SecretCollection {
     /// Returns the created Collection.
     pub fn create(label: &str, alias: Option<&str>) -> SecretResult<SecretCollection> {
         let mut err = ptr::null_mut();
-        let ptr = unsafe{ffi::secret_collection_create_sync(ptr::null_mut(), label.to_glib_none().0, alias.to_glib_none().0, 0 as c_int, ptr::null_mut(), &mut err)};
+        let ptr = unsafe{ffi::secret_collection_create_sync(ptr::null_mut(), label.to_glib_none().0, alias.to_glib_none().0, 0, ptr::null_mut(), &mut err)};
         if err.is_null(){
             Ok(unsafe { from_glib_full(ptr) })
         } else {

--- a/src/secret_collection.rs
+++ b/src/secret_collection.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 use libc::{c_int};
 use glib::Error;
-use glib::object::{Wrapper, Ref};
+use glib::object::{Object, Upcast, Wrapper, Ref};
 use glib::types::{StaticType, Type};
 use glib::translate::*;
 use glib::glib_container::GlibContainer;
@@ -109,6 +109,8 @@ impl StaticType for SecretCollection {
         unsafe { from_glib(ffi::secret_collection_get_type()) }
     }
 }
+
+unsafe impl Upcast<Object> for SecretCollection { }
 
 impl Wrapper for SecretCollection {
     type GlibType = ffi::SecretCollectionFFI;


### PR DESCRIPTION
I'd like to propose an example of how I intended the `glib::object` and `translate` APIs to be used along with a bug fix. This will hopefully be instructive on how to improve the other modules.

I also recommend against using names that don't match the C headers in the `sys` crate (`SecretCollectionFFI` vs `SecretCollection`). You can refer to the foreign types as `ffi::SecretCollection` so name clashes are not a concern.
